### PR TITLE
Move sql code to sqls.py

### DIFF
--- a/projektrouska/aktualnost/kontrola.py
+++ b/projektrouska/aktualnost/kontrola.py
@@ -20,7 +20,7 @@ def check_in_db(to_check):
     zmena_odkazu = []
     cekajici_na_zpracovani = []
 
-    print("Kotrnoluju soubor déky {}: \n{}".format(len(to_check), str(to_check)))
+    print("Kontroluju soubor dékly {}: \n{}".format(len(to_check), str(to_check)))
     # na jednom linku muze byt i vice narizeni, tak projed pro kazde
     for o in to_check:
         if o["odkaz"] in blacklist:

--- a/projektrouska/aktualnost/kontrola.py
+++ b/projektrouska/aktualnost/kontrola.py
@@ -20,7 +20,7 @@ def check_in_db(to_check):
     zmena_odkazu = []
     cekajici_na_zpracovani = []
 
-    print("Kontroluju soubor dékly {}: \n{}".format(len(to_check), str(to_check)))
+    print("Kontroluju soubor délky {}: \n{}".format(len(to_check), str(to_check)))
     # na jednom linku muze byt i vice narizeni, tak projed pro kazde
     for o in to_check:
         if o["odkaz"] in blacklist:

--- a/projektrouska/functions.py
+++ b/projektrouska/functions.py
@@ -38,17 +38,15 @@ def return_as_dict(data, description):
     :return: return dictionary of tuples {desc[0]: data[0], desc[1]: data[1]}
     """
     columns = [column[0] for column in description]
-    dict = {}
+    dictionary = {}
     if data:
-        i = 0
-        for value in data:
-            dict[columns[i]] = value
-            i += 1
+        for i in range(len(data)):
+            dictionary[columns[i]] = data[i]
     else:
         for column in columns:
-            dict[column] = None
+            dictionary[column] = None
 
-    return dict
+    return dictionary
 
 
 def calcmd5(string):

--- a/projektrouska/functions.py
+++ b/projektrouska/functions.py
@@ -59,9 +59,25 @@ def calcmd5(string):
     # printing the equivalent hexadecimal value.
     return result.hexdigest()
 
+
 # source: https://stackoverflow.com/questions/8906926/formatting-timedelta-objects
 def strfdelta(tdelta, fmt):
     d = {"days": tdelta.days}
     d["hours"], rem = divmod(tdelta.seconds, 3600)
     d["minutes"], d["seconds"] = divmod(rem, 60)
     return fmt.format(**d)
+
+
+def display_by_cath(array):
+    by_cath = []
+    existing = []
+    for col in array:
+        if "NAZEV_KAT" in col:
+            # fajn, ted zkontroluju, jestli uz jsem to vypsal, nebo ne
+            if col["NAZEV_KAT"] in existing:
+                by_cath[len(by_cath) - 1]["narizeni"].append(col)
+            else:
+                existing.append(col["NAZEV_KAT"])
+                tmp = {"kategorie": col["NAZEV_KAT"], "narizeni": [col]}
+                by_cath.append(tmp)
+    return by_cath

--- a/projektrouska/functions.py
+++ b/projektrouska/functions.py
@@ -27,25 +27,27 @@ def return_as_array(data, description):
 
 def return_as_dict(data, description):
     """
-
     :param data: return value of  cursor.execute.fetchone (single row only!)
+    example:
+        ('355e8aa9b2f3d0be96a75b028815c80a', datetime.datetime(2020, 10, 24, 22, 54), 'Všechna data jsou aktuální!', 100, 0, '[]', 0, '[]', 0, '[]', 0, 41825)
+
     :param description:  value of cursor.description
+    example:
+        [('CHECKSUM', <cx_Oracle.DbType DB_TYPE_VARCHAR>, 50, 50, None, None, 1), ('DATE_UPDATED', <cx_Oracle.DbType DB_TYPE_DATE>, 23, None, None, None, 1), ('POZNAMKA', <cx_Oracle.DbType DB_TYPE_VARCHAR>, 500, 500, None, None, 1), ('AKTUALNOST', <cx_Oracle.DbType DB_TYPE_NUMBER>, 39, None, 38, 0, 1), ('CHYBI_POCET', <cx_Oracle.DbType DB_TYPE_NUMBER>, 39, None, 38, 0, 0), ('CHYBI_POLE', <cx_Oracle.DbType DB_TYPE_VARCHAR>, 4000, 4000, None, None, 1), ('ZMENA_LINK_POCET', <cx_Oracle.DbType DB_TYPE_NUMBER>, 39, None, 38, 0, 1), ('ZMENA_LINK_POLE', <cx_Oracle.DbType DB_TYPE_VARCHAR>, 4000, 4000, None, None, 1), ('ODSTRANIT_POCET', <cx_Oracle.DbType DB_TYPE_NUMBER>, 39, None, 38, 0, 1), ('ODSTRANIT_POLE', <cx_Oracle.DbType DB_TYPE_VARCHAR>, 4000, 4000, None, None, 1), ('CELK_ZMEN', <cx_Oracle.DbType DB_TYPE_NUMBER>, 39, None, 38, 0, 1), ('ID', <cx_Oracle.DbType DB_TYPE_NUMBER>, 39, None, 38, 0, 0)]
+
     :return: return dictionary of tuples {desc[0]: data[0], desc[1]: data[1]}
     """
-    desc = description  # pouzivam dale, kde se z techle dat dela neco jako slovnik, co uz django schrousta
-    columns = []
-    for col in desc:
-        columns.append(col[0])
+    columns = [column[0] for column in description]
     dict = {}
-    i = 0
     if data:
-        for row in data:
-            dict[columns[i]] = row
+        i = 0
+        for value in data:
+            dict[columns[i]] = value
             i += 1
     else:
-        for col in columns:
-            dict[columns[i]] = None
-            i += 1
+        for column in columns:
+            dict[column] = None
+
     return dict
 
 
@@ -80,4 +82,5 @@ def display_by_cath(array):
                 existing.append(col["NAZEV_KAT"])
                 tmp = {"kategorie": col["NAZEV_KAT"], "narizeni": [col]}
                 by_cath.append(tmp)
+
     return by_cath

--- a/projektrouska/functions.py
+++ b/projektrouska/functions.py
@@ -58,3 +58,10 @@ def calcmd5(string):
 
     # printing the equivalent hexadecimal value.
     return result.hexdigest()
+
+# source: https://stackoverflow.com/questions/8906926/formatting-timedelta-objects
+def strfdelta(tdelta, fmt):
+    d = {"days": tdelta.days}
+    d["hours"], rem = divmod(tdelta.seconds, 3600)
+    d["minutes"], d["seconds"] = divmod(rem, 60)
+    return fmt.format(**d)

--- a/projektrouska/sqls.py
+++ b/projektrouska/sqls.py
@@ -1,0 +1,30 @@
+from django.db import connection
+
+from projektrouska.functions import return_as_dict, return_as_array, calcmd5, format_num
+
+
+def posledni_kontrola():
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT
+                *
+            FROM
+                (select * from INFO order by DATE_UPDATED desc )
+            WHERE
+                rownum <= 1;"""
+        )
+        dict = return_as_dict(cursor.fetchone(), cursor.description)
+        print(dict)
+        return dict
+
+
+def posledni_databaze():
+    with connection.cursor() as cursor:
+        last_qu = """select max(posledni_uprava) from(
+                       SELECT SCN_TO_TIMESTAMP(MAX(ora_rowscn)) as posledni_uprava from polozka
+                       union
+                       SELECT SCN_TO_TIMESTAMP(MAX(ora_rowscn)) as posledni_uprava from opatreni)"""
+        cursor.execute(last_qu)
+        last_update = cursor.fetchone()
+        return last_update[0]

--- a/projektrouska/sqls.py
+++ b/projektrouska/sqls.py
@@ -18,16 +18,8 @@ DNI_DOPREDU = 7
 
 def posledni_kontrola():
     with connection.cursor() as cursor:
-        cursor.execute(
-            """
-            SELECT
-                *
-            FROM
-                (select * from INFO order by DATE_UPDATED desc )
-            WHERE
-                rownum <= 1;
-            """
-        )
+        query = """select * from (select * from INFO order by DATE_UPDATED desc) where rownum <= 1;"""
+        cursor.execute(query)
         dict = return_as_dict(cursor.fetchone(), cursor.description)
         # print(dict)
         return dict
@@ -38,7 +30,7 @@ def posledni_databaze():
         last_qu = """select max(posledni_uprava) from(
                        SELECT SCN_TO_TIMESTAMP(MAX(ora_rowscn)) as posledni_uprava from polozka
                        union
-                       SELECT SCN_TO_TIMESTAMP(MAX(ora_rowscn)) as posledni_uprava from opatreni)"""
+                       SELECT SCN_TO_TIMESTAMP(MAX(ora_rowscn)) as posledni_uprava from opatreni);"""
         cursor.execute(last_qu)
         last_update = cursor.fetchone()
         return last_update[0]
@@ -71,7 +63,7 @@ def opatreni_stat():
 
 
                 ) join polozka on id_opatreni=opatreni_id_opatreni
-            ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie) order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc"""
+            ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie) order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc;"""
     with connection.cursor() as cursor:
         cursor.execute(qu, {"zobrazit_dopredu": DNI_DOPREDU})
         array = return_as_array(cursor.fetchall(), cursor.description)

--- a/projektrouska/sqls.py
+++ b/projektrouska/sqls.py
@@ -1,6 +1,19 @@
+from datetime import datetime, timedelta
+
 from django.db import connection
 
-from projektrouska.functions import return_as_dict, return_as_array, calcmd5, format_num
+
+from projektrouska.functions import (
+    return_as_dict,
+    return_as_array,
+    # calcmd5,
+    # format_num,
+    strfdelta,
+    display_by_cath,
+)
+
+# urcuje v horizontu kolika dni se maji zobrazovat nadchazející opatreni
+DNI_DOPREDU = 7
 
 
 def posledni_kontrola():
@@ -12,10 +25,11 @@ def posledni_kontrola():
             FROM
                 (select * from INFO order by DATE_UPDATED desc )
             WHERE
-                rownum <= 1;"""
+                rownum <= 1;
+            """
         )
         dict = return_as_dict(cursor.fetchone(), cursor.description)
-        print(dict)
+        # print(dict)
         return dict
 
 
@@ -28,3 +42,412 @@ def posledni_databaze():
         cursor.execute(last_qu)
         last_update = cursor.fetchone()
         return last_update[0]
+
+
+def zastarala_data():
+    posledni_datetime = posledni_kontrola()["DATE_UPDATED"]
+    naposledy_provedeno = datetime.now() - posledni_datetime
+    str_naposledy = strfdelta(
+        naposledy_provedeno, "{days} dny, {hours} hodinami {minutes} minutami"
+    )  # {seconds} vteřinami
+    if (datetime.now() - posledni_datetime) < timedelta(minutes=60):
+        return {
+            "zastarala_data": False,
+            "posledni_uspesna_kontrola_timespan": str_naposledy,
+        }
+    return {"zastarala_data": True, "posledni_uspesna_kontrola_timespan": str_naposledy}
+
+
+def opatreni_stat():
+    qu = """ select * from (
+            select * from 
+            (
+                select * from
+                (
+                    -- stat 
+                    select distinct null as nazev_obecmesto, null as  nazev_nuts, null as nazev_okres, null as nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava  from (
+                    select * from OP_STAT join OPATRENI using(id_opatreni)  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                    )
+
+
+                ) join polozka on id_opatreni=opatreni_id_opatreni
+            ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie) order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc"""
+    with connection.cursor() as cursor:
+        cursor.execute(qu, {"zobrazit_dopredu": DNI_DOPREDU})
+        array = return_as_array(cursor.fetchall(), cursor.description)
+        location = {}
+        return display_by_cath(array), location
+
+
+def opatreni_nuts(id_nuts):
+    qu = """
+
+
+                       select * from
+                       (
+                           select * from (
+
+
+                           -- nuts3
+                           select  null as nazev_obecmesto, nazev_nuts, nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni,nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava from (
+                              select *
+                              from (
+                                       select *
+                                       from (
+                                                select *
+                                                from (
+                                                         select *
+                                                         from (
+                                                                  select ID_NUTS as NUTS3_ID_NUTS, NAZEV_NUTS, KRAJ_ID_KRAJ as ID_KRAJ
+                                                                  from nuts3
+                                                                  where id_nuts = :id_nuts
+                                                              )
+                                                                  join OKRES using (NUTS3_ID_NUTS)
+                                                     )
+                                                         join kraj using (ID_KRAJ)
+                                            )
+                                   )join op_nuts using(nuts3_id_nuts)
+                           )join opatreni on opatreni_id_opatreni=opatreni.id_opatreni where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                           union
+
+                           -- okres
+                           select  null as nazev_obecmesto, nazev_nuts, nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava   from
+                           (
+                               select * from
+                               (
+                                   select * from (
+                                       select * from
+                                       (
+                                          select id_nuts, nazev_nuts, kod_nuts, kraj_id_kraj as id_kraj from nuts3 where id_nuts=:id_nuts
+
+                                       ) join OKRES on ID_NUTS=OKRES.NUTS3_ID_NUTS
+                                   ) join kraj using(ID_KRAJ)
+                               )
+                               join OP_OKRES on OP_OKRES.OKRES_ID_OKRES=ID_OKRES)
+                           join opatreni on opatreni_id_opatreni=opatreni.id_opatreni where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                           union
+                           -- kraj
+                           select null as nazev_obecmesto, nazev_nuts, nazev_okres,  nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do , platnost_autooprava, zdroj_autooprava, nazev_autooprava from
+                           (
+                               select * from
+                               (
+                                   select * from
+                                   (
+                                       select * from
+                                       (
+                                          select KRAJ_ID_KRAJ as id_kraj, id_nuts, NAZEV_NUTS, kod_nuts from nuts3 where id_nuts=:id_nuts
+
+                                       ) join OKRES on ID_NUTS=OKRES.NUTS3_ID_NUTS
+                                   ) join op_kraj on op_kraj.kraj_id_kraj=id_kraj
+                               ) join opatreni on opatreni_id_opatreni=opatreni.id_opatreni  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                           ) join kraj using(id_kraj)
+                           -- stat
+                           union
+
+                           select null as nazev_obecmesto, null as nazev_nuts, null as nazev_okres, null as nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do , platnost_autooprava, zdroj_autooprava, nazev_autooprava from (
+                           select * from OP_STAT join OPATRENI using(id_opatreni) where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                               )
+
+                       ) join polozka on opatreni_id_opatreni = id_opatreni
+                   ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc"""
+
+    misto_qu = """select null as nazev_obecmesto, nazev_nuts, nazev_okres, nazev_kraj from (
+                 select * from (
+                              select ID_NUTS, NAZEV_NUTS, KRAJ_ID_KRAJ as id_kraj from nuts3 where ID_NUTS=:id_nuts
+                     )join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
+                   ) join kraj using(id_kraj);"""
+
+    with connection.cursor() as cursor:
+        cursor.execute(qu, {"id_nuts": id_nuts, "zobrazit_dopredu": DNI_DOPREDU})
+        array = return_as_array(cursor.fetchall(), cursor.description)
+
+        cursor.execute(misto_qu, {"id_nuts": id_nuts})
+        location = return_as_dict(cursor.fetchone(), cursor.description)
+        return display_by_cath(array), location
+
+
+def opatreni_kraj(id_kraj):
+    qu = """ select * from (
+            select * from 
+            (
+                select * from
+                (
+                    -- kraj 
+                    select null as nazev_obecmesto, null as nazev_nuts, null as  nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava  from 
+                    (
+                        select * from 
+                        (
+                            select * from 
+                            (
+                                select id_kraj as kraj_id_kraj, nazev_kraj from kraj where id_kraj=:id_k 
+                            ) join op_kraj using(kraj_id_kraj)
+                        ) join opatreni on opatreni_id_opatreni=opatreni.id_opatreni   where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                    )
+                    union 
+                    -- stat 
+                    select distinct null as nazev_obecmesto, null as  nazev_nuts, null as nazev_okres, null as nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava  from (
+                    select * from OP_STAT join OPATRENI using(id_opatreni)  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                    )
+
+
+                ) join polozka on id_opatreni=opatreni_id_opatreni
+            ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie) order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc"""
+    misto_qu = """select null as nazev_obecmesto, null as nazev_nuts, null as nazev_okres, nazev_kraj from (
+              select * from kraj  where id_kraj=:id_k) """
+
+    with connection.cursor() as cursor:
+        cursor.execute(qu, {"id_k": id_kraj, "zobrazit_dopredu": DNI_DOPREDU})
+        array = return_as_array(cursor.fetchall(), cursor.description)
+
+        cursor.execute(misto_qu, {"id_k": id_kraj})
+        location = return_as_dict(cursor.fetchone(), cursor.description)
+        return display_by_cath(array), location
+
+
+def opatreni_okres(id_okres):
+    qu = """select * from (
+                  select * from (
+                         -- okres
+                          select  null as nazev_obecmesto, null as  nazev_nuts, nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni,nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do , platnost_autooprava, zdroj_autooprava, nazev_autooprava  from (
+
+                              select * from
+                              (
+                                  select * from OKRES  where ID_OKRES = :id_okr
+                              ) join kraj on kraj.id_kraj=KRAJ_ID_KRAJ
+                              join op_okres on op_okres.okres_id_okres=id_okres
+                              )
+                          join opatreni on opatreni_id_opatreni=opatreni.id_opatreni   where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                          union
+                          -- kraj
+
+                          select null as nazev_obecmesto, null as  nazev_nuts, nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do , platnost_autooprava, zdroj_autooprava, nazev_autooprava from (
+                          select * from (
+                                  select * from
+                                  (
+                                      select * from OKRES  where ID_OKRES = :id_okr
+                                  ) join op_kraj using(KRAJ_ID_KRAJ)
+                              ) join opatreni on opatreni_id_opatreni=opatreni.id_opatreni  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                              ) join kraj on KRAJ_ID_KRAJ=kraj.id_kraj
+
+                          union
+
+                          select distinct null as nazev_obecmesto, null as  nazev_nuts, null as nazev_okres, null as nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,  ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava from
+                         (
+                          select * from OP_STAT join OPATRENI using(id_opatreni)  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                         )
+
+                          ) join polozka on id_opatreni=opatreni_id_opatreni
+                      ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc"""
+    misto_qu = """select distinct null as nazev_obecmesto, null as nazev_nuts, nazev_okres, nazev_kraj from (
+                               select * from (
+                                        select *
+                                        from okres
+                                        where ID_OKRES = :id_okr
+                                    )join kraj on kraj.id_kraj = KRAJ_ID_KRAJ
+                              );"""
+
+    with connection.cursor() as cursor:
+        cursor.execute(qu, {"id_okr": id_okres, "zobrazit_dopredu": DNI_DOPREDU})
+        array = return_as_array(cursor.fetchall(), cursor.description)
+
+        cursor.execute(misto_qu, {"id_okr": id_okres})
+        location = return_as_dict(cursor.fetchone(), cursor.description)
+        return display_by_cath(array), location
+
+
+def opatreni_om(id_obecmesto):
+    qu = """
+             select * from (
+         select * from (
+                               -- lokalni
+                               select nazev_obecmesto,
+                                      nazev_nuts,
+                                      nazev_okres,
+                                      nazev_kraj,
+                                      id_opatreni,
+                                      nazev_opatreni,
+                                      nazev_zkr,
+                                      zdroj,
+                                      ROZSAH,
+                                      platnost_od,
+                                      platnost_do, 
+                                      platnost_autooprava, 
+                                      zdroj_autooprava,
+                                      nazev_autooprava
+                               from (
+                                        select *
+                                        from (
+                                                 select *
+                                                 from (
+                                                          select *
+                                                          from (
+                                                                   select *
+                                                                   from (
+                                                                            select *
+                                                                            from (select * from obecmesto where id_obecmesto = :id_ob)
+                                                                        )
+                                                                            join nuts3 on nuts3_id_nuts = nuts3.id_nuts
+                                                               )
+                                                                   join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
+                                                      )
+                                                          join kraj on kraj.id_kraj = nuts3_kraj_id_kraj
+                                             )
+                                                 join op_om on id_obecmesto = op_om.obecmesto_id_obecmesto
+                                    )
+                                        join opatreni on opatreni_id_opatreni = opatreni.id_opatreni
+                               where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
+                                 and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+
+                               union
+                               -- nuts3
+                               select nazev_obecmesto,
+                                      nazev_nuts,
+                                      nazev_okres,
+                                      nazev_kraj,
+                                      id_opatreni,
+                                      nazev_opatreni,
+                                      nazev_zkr,
+                                      zdroj,
+                                      ROZSAH,
+                                      platnost_od,
+                                      platnost_do,
+                                      platnost_autooprava, 
+                                      zdroj_autooprava, 
+                                      nazev_autooprava
+                               from (
+                                        select *
+                                        from (
+                                                 select *
+                                                 from (
+                                                          select *
+                                                          from (
+                                                                   select *
+                                                                   from (select * from obecmesto where id_obecmesto = :id_ob)
+                                                                            join nuts3 on nuts3_id_nuts = nuts3.id_nuts
+                                                               )
+                                                      )
+                                                          join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
+                                             )
+                                                 join kraj on kraj.id_kraj = nuts3_kraj_id_kraj
+                                                 join op_nuts on op_nuts.nuts3_id_nuts = id_nuts)
+                                        join opatreni on opatreni_id_opatreni = opatreni.id_opatreni
+                               where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
+                                 and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+
+                               union
+                               -- okres
+                               select nazev_obecmesto,
+                                      nazev_nuts,
+                                      nazev_okres,
+                                      nazev_kraj,
+                                      id_opatreni,
+                                      nazev_opatreni,
+                                      nazev_zkr,
+                                      zdroj,
+                                      ROZSAH,
+                                      platnost_od,
+                                      platnost_do,
+                                      platnost_autooprava, 
+                                      zdroj_autooprava, 
+                                      nazev_autooprava
+                               from (
+                                        select *
+                                        from (
+                                                 select *
+                                                 from (
+                                                          select *
+                                                          from (
+                                                                   select *
+                                                                   from (select * from obecmesto where id_obecmesto = :id_ob)
+                                                                            join nuts3 on nuts3_id_nuts = nuts3.id_nuts)
+                                                      )
+                                                          join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
+                                             )
+                                                 join kraj on kraj.id_kraj = nuts3_kraj_id_kraj
+                                                 join op_okres on op_okres.okres_id_okres = id_okres
+                                    )
+                                        join opatreni on opatreni_id_opatreni = opatreni.id_opatreni
+                               where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
+                                 and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+
+                               union
+                               -- kraj
+
+                               select nazev_obecmesto,
+                                      nazev_nuts,
+                                      nazev_okres,
+                                      nazev_kraj,
+                                      id_opatreni,
+                                      nazev_opatreni,
+                                      nazev_zkr,
+                                      zdroj,
+                                      ROZSAH,
+                                      platnost_od,
+                                      platnost_do,
+                                      platnost_autooprava, 
+                                      zdroj_autooprava, 
+                                      nazev_autooprava
+                               from (
+                                        select *
+                                        from (
+                                                 select *
+                                                 from (
+                                                          select *
+                                                          from (
+                                                                   select *
+                                                                   from (select * from obecmesto where id_obecmesto = :id_ob)
+                                                                            join nuts3 on nuts3_id_nuts = nuts3.id_nuts
+                                                               )
+                                                                   join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
+                                                      )
+                                                          join op_kraj on op_kraj.kraj_id_kraj = nuts3_kraj_id_kraj
+                                             )
+                                                 join opatreni on opatreni_id_opatreni = opatreni.id_opatreni
+                                        where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
+                                          and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                                    )
+                                        join kraj on nuts3_kraj_id_kraj = kraj.id_kraj
+
+                                    -- stat
+                               union
+
+                               select null as nazev_obecmesto,
+                                      null as nazev_nuts,
+                                      null as nazev_okres,
+                                      null as nazev_kraj,
+                                      id_opatreni,
+                                      nazev_opatreni,
+                                      nazev_zkr,
+                                      zdroj,
+                                      ROZSAH,
+                                      platnost_od,
+                                      platnost_do,
+                                      platnost_autooprava, 
+                                      zdroj_autooprava, 
+                                      nazev_autooprava
+                               from (
+                                        select *
+                                        from OP_STAT
+                                                 join OPATRENI using (id_opatreni)
+                                        where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
+                                          and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
+                                    )
+                           )
+               )join polozka on id_opatreni=opatreni_id_opatreni
+              join kategorie on kategorie.id_kategorie=kategorie_id_kategorie order by PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc 
+              """
+    misto_qu = """select nazev_obecmesto, nazev_nuts, nazev_okres, nazev_kraj from (
+               select * from (
+                        select * from (
+                            select * from obecmesto where id_obecmesto=:id_ob
+                            ) join nuts3 on nuts3_id_nuts = nuts3.id_nuts
+                   )join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
+                 ) join kraj on kraj.id_kraj=nuts3_kraj_id_kraj;"""
+    with connection.cursor() as cursor:
+        cursor.execute(qu, {"id_ob": id_obecmesto, "zobrazit_dopredu": DNI_DOPREDU})
+        array = return_as_array(cursor.fetchall(), cursor.description)
+
+        cursor.execute(misto_qu, {"id_ob": id_obecmesto})
+        location = return_as_dict(cursor.fetchone(), cursor.description)
+
+        return display_by_cath(array), location

--- a/projektrouska/sqls.py
+++ b/projektrouska/sqls.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from django.db import connection
 
-
 from projektrouska.functions import (
     return_as_dict,
     return_as_array,
@@ -20,9 +19,8 @@ def posledni_kontrola():
     with connection.cursor() as cursor:
         query = """select * from (select * from INFO order by DATE_UPDATED desc) where rownum <= 1;"""
         cursor.execute(query)
-        dict = return_as_dict(cursor.fetchone(), cursor.description)
-        # print(dict)
-        return dict
+        dictionary = return_as_dict(cursor.fetchone(), cursor.description)
+        return dictionary
 
 
 def posledni_databaze():
@@ -32,8 +30,8 @@ def posledni_databaze():
                        union
                        SELECT SCN_TO_TIMESTAMP(MAX(ora_rowscn)) as posledni_uprava from opatreni);"""
         cursor.execute(last_qu)
-        last_update = cursor.fetchone()
-        return last_update[0]
+        last_update = cursor.fetchone()[0]
+        return last_update
 
 
 def zastarala_data():

--- a/projektrouska/urls.py
+++ b/projektrouska/urls.py
@@ -40,11 +40,11 @@ from projektrouska.view.errors import (
 
 urlpatterns = [
     # path('admin/', admin.site.urls),
-    path("", views.opaterni_celoplosne, name="home"),
+    path("", views.opatreni_celoplosne, name="home"),
     path("home/", views.home, name="home"),
     path("o-projektu/", views.about, name="about"),
     path("opatreni/", views.opatreni, name="opatreni"),
-    path("celostatni-opatreni/", views.opaterni_celoplosne, name="celostatni-opatreni"),
+    path("celostatni-opatreni/", views.opatreni_celoplosne, name="celostatni-opatreni"),
     path("aktualnost/", views.aktualnost, name="aktualnost"),
     path("robots.txt", views.robots_txt),
     # path('statistiky/', views.stats, name='statistiky'),

--- a/projektrouska/view/errors.py
+++ b/projektrouska/view/errors.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 from datetime import datetime
-from projektrouska.views import posledni_databaze
-from projektrouska.views import posledni_kontrola
+from projektrouska.sqls import posledni_databaze
+from projektrouska.sqls import posledni_kontrola
 
 
 def custom_page_not_found_view(request, exception):

--- a/projektrouska/views.py
+++ b/projektrouska/views.py
@@ -19,490 +19,82 @@ from projektrouska.functions import (
     return_as_array,
     calcmd5,
     format_num,
-    strfdelta,
+    # strfdelta,
+    display_by_cath,
 )
 from projektrouska.api import *
 
-from projektrouska.sqls import posledni_kontrola, posledni_databaze
-
-# urcuje v horizontu kolika dni se maji zobrazovat nadchazející opatreni
-DNI_DOPREDU = 7
-
-
-def zastarala_data():
-    posledni_datetime = posledni_kontrola()["DATE_UPDATED"]
-    naposledy_povedeno = datetime.now() - posledni_datetime
-    str_naposledy = strfdelta(
-        naposledy_povedeno, "{days} dny, {hours} hodinami {minutes} minutami"
-    )  # {seconds} vteřinami
-    if (datetime.now() - posledni_datetime) < timedelta(minutes=60):
-        return {
-            "zastarala_data": False,
-            "posledni_uspesna_kontrola_timespan": str_naposledy,
-        }
-    return {"zastarala_data": True, "posledni_uspesna_kontrola_timespan": str_naposledy}
+from projektrouska.sqls import (
+    posledni_kontrola,
+    posledni_databaze,
+    zastarala_data,
+    opatreni_stat,
+    opatreni_kraj,
+    opatreni_nuts,
+    opatreni_okres,
+    opatreni_om,
+)
 
 
-def aktualnost_v_case(request):
-    """select min(DATE_UPDATED) as DATE_UPDATED, POZNAMKA, AKTUALNOST, CHYBI_POCET, CHYBI_POLE, ZMENA_LINK_POCET, ZMENA_LINK_POLE, ODSTRANIT_POCET, ODSTRANIT_POLE, CELK_ZMEN from info
-group by CHECKSUM, POZNAMKA, AKTUALNOST, CHYBI_POCET, CHYBI_POLE, ZMENA_LINK_POCET, ZMENA_LINK_POLE, ODSTRANIT_POCET, ODSTRANIT_POLE, CELK_ZMEN
-order by  DATE_UPDATED"""
-    pass
+# # TODO Dokoncit seznam narizeni a polozek
+# def seznam_opatreni(request):
+#     with connection.cursor() as cursor:
+
+#         cursor.execute(
+#             """select * from (select * from opatreni ) join polozka on ID_OPATRENI=OPATRENI_ID_OPATRENI join KATEGORIE K on K.ID_KATEGORIE = POLOZKA.KATEGORIE_ID_KATEGORIE order by je_platne desc, PLATNOST_OD desc)"""
+#         )
+
+#         query_results = cursor.fetchall()
+
+#         desc = (
+#             cursor.description
+#         )  # pouzivam dale, kde se z techle dat dela neco jako slovnik, co uz django schrousta
+
+#         # MAGIC #
+#         columns = []
+#         for col in desc:
+#             columns.append(col[0])
+
+#         a = []
+
+#         for line in query_results:
+#             temp = {}
+#             for i in range(0, len(line)):
+#                 temp[columns[i]] = line[i]
+#             a.append(temp)
+
+#         location = {}
+#         i = 0
+#         # setrizene podle kategorie
+#         by_cath = []
+
+#         existing = []
+#         for col in a:
+#             if (
+#                 "NAZEV_KAT" in col
+#             ):  # fajn, ted zkontroluju, jestli uz jsem to vypsal, nebo ne
+#                 if col["NAZEV_KAT"] in existing:
+#                     by_cath[len(by_cath) - 1]["narizeni"].append(col)
+#                 else:
+#                     existing.append(col["NAZEV_KAT"])
+#                     tmp = {"kategorie": col["NAZEV_KAT"], "narizeni": [col]}
+#                     by_cath.append(tmp)
+
+#         return render(
+#             request,
+#             "sites/opatreni.html",
+#             {
+#                 "query_results": by_cath,
+#                 "location": location,
+#                 "posledni_databaze": posledni_databaze(),
+#                 "now": datetime.now(),
+#                 "kontrola": posledni_kontrola(),
+#                 "zastarala_data": zastarala_data(),
+#             },
+#         )
 
 
-def opatreni_stat():
-    qu = """ select * from (
-            select * from 
-            (
-                select * from
-                (
-                    -- stat 
-                    select distinct null as nazev_obecmesto, null as  nazev_nuts, null as nazev_okres, null as nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava  from (
-                    select * from OP_STAT join OPATRENI using(id_opatreni)  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                    )
-
-
-                ) join polozka on id_opatreni=opatreni_id_opatreni
-            ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie) order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc"""
-    with connection.cursor() as cursor:
-        cursor.execute(qu, {"zobrazit_dopredu": DNI_DOPREDU})
-        array = return_as_array(cursor.fetchall(), cursor.description)
-        location = {}
-        return display_by_cath(array), location
-
-
-def opatreni_nuts(id_nuts):
-    qu = """
-
-
-                       select * from
-                       (
-                           select * from (
-
-
-                           -- nuts3
-                           select  null as nazev_obecmesto, nazev_nuts, nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni,nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava from (
-                              select *
-                              from (
-                                       select *
-                                       from (
-                                                select *
-                                                from (
-                                                         select *
-                                                         from (
-                                                                  select ID_NUTS as NUTS3_ID_NUTS, NAZEV_NUTS, KRAJ_ID_KRAJ as ID_KRAJ
-                                                                  from nuts3
-                                                                  where id_nuts = :id_nuts
-                                                              )
-                                                                  join OKRES using (NUTS3_ID_NUTS)
-                                                     )
-                                                         join kraj using (ID_KRAJ)
-                                            )
-                                   )join op_nuts using(nuts3_id_nuts)
-                           )join opatreni on opatreni_id_opatreni=opatreni.id_opatreni where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                           union
-
-                           -- okres
-                           select  null as nazev_obecmesto, nazev_nuts, nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava   from
-                           (
-                               select * from
-                               (
-                                   select * from (
-                                       select * from
-                                       (
-                                          select id_nuts, nazev_nuts, kod_nuts, kraj_id_kraj as id_kraj from nuts3 where id_nuts=:id_nuts
-
-                                       ) join OKRES on ID_NUTS=OKRES.NUTS3_ID_NUTS
-                                   ) join kraj using(ID_KRAJ)
-                               )
-                               join OP_OKRES on OP_OKRES.OKRES_ID_OKRES=ID_OKRES)
-                           join opatreni on opatreni_id_opatreni=opatreni.id_opatreni where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                           union
-                           -- kraj
-                           select null as nazev_obecmesto, nazev_nuts, nazev_okres,  nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do , platnost_autooprava, zdroj_autooprava, nazev_autooprava from
-                           (
-                               select * from
-                               (
-                                   select * from
-                                   (
-                                       select * from
-                                       (
-                                          select KRAJ_ID_KRAJ as id_kraj, id_nuts, NAZEV_NUTS, kod_nuts from nuts3 where id_nuts=:id_nuts
-
-                                       ) join OKRES on ID_NUTS=OKRES.NUTS3_ID_NUTS
-                                   ) join op_kraj on op_kraj.kraj_id_kraj=id_kraj
-                               ) join opatreni on opatreni_id_opatreni=opatreni.id_opatreni  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                           ) join kraj using(id_kraj)
-                           -- stat
-                           union
-
-                           select null as nazev_obecmesto, null as nazev_nuts, null as nazev_okres, null as nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do , platnost_autooprava, zdroj_autooprava, nazev_autooprava from (
-                           select * from OP_STAT join OPATRENI using(id_opatreni) where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                               )
-
-                       ) join polozka on opatreni_id_opatreni = id_opatreni
-                   ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc"""
-
-    misto_qu = """select null as nazev_obecmesto, nazev_nuts, nazev_okres, nazev_kraj from (
-                 select * from (
-                              select ID_NUTS, NAZEV_NUTS, KRAJ_ID_KRAJ as id_kraj from nuts3 where ID_NUTS=:id_nuts
-                     )join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
-                   ) join kraj using(id_kraj);"""
-
-    with connection.cursor() as cursor:
-        cursor.execute(qu, {"id_nuts": id_nuts, "zobrazit_dopredu": DNI_DOPREDU})
-        array = return_as_array(cursor.fetchall(), cursor.description)
-
-        cursor.execute(misto_qu, {"id_nuts": id_nuts})
-        location = return_as_dict(cursor.fetchone(), cursor.description)
-        return display_by_cath(array), location
-
-
-def opatreni_kraj(id_kraj):
-    qu = """ select * from (
-            select * from 
-            (
-                select * from
-                (
-                    -- kraj 
-                    select null as nazev_obecmesto, null as nazev_nuts, null as  nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava  from 
-                    (
-                        select * from 
-                        (
-                            select * from 
-                            (
-                                select id_kraj as kraj_id_kraj, nazev_kraj from kraj where id_kraj=:id_k 
-                            ) join op_kraj using(kraj_id_kraj)
-                        ) join opatreni on opatreni_id_opatreni=opatreni.id_opatreni   where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                    )
-                    union 
-                    -- stat 
-                    select distinct null as nazev_obecmesto, null as  nazev_nuts, null as nazev_okres, null as nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava  from (
-                    select * from OP_STAT join OPATRENI using(id_opatreni)  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                    )
-
-
-                ) join polozka on id_opatreni=opatreni_id_opatreni
-            ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie) order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc"""
-    misto_qu = """select null as nazev_obecmesto, null as nazev_nuts, null as nazev_okres, nazev_kraj from (
-              select * from kraj  where id_kraj=:id_k) """
-
-    with connection.cursor() as cursor:
-        cursor.execute(qu, {"id_k": id_kraj, "zobrazit_dopredu": DNI_DOPREDU})
-        array = return_as_array(cursor.fetchall(), cursor.description)
-
-        cursor.execute(misto_qu, {"id_k": id_kraj})
-        location = return_as_dict(cursor.fetchone(), cursor.description)
-        return display_by_cath(array), location
-
-
-def opatreni_okres(id_okres):
-    qu = """select * from (
-                  select * from (
-                         -- okres
-                          select  null as nazev_obecmesto, null as  nazev_nuts, nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni,nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do , platnost_autooprava, zdroj_autooprava, nazev_autooprava  from (
-
-                              select * from
-                              (
-                                  select * from OKRES  where ID_OKRES = :id_okr
-                              ) join kraj on kraj.id_kraj=KRAJ_ID_KRAJ
-                              join op_okres on op_okres.okres_id_okres=id_okres
-                              )
-                          join opatreni on opatreni_id_opatreni=opatreni.id_opatreni   where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                          union
-                          -- kraj
-
-                          select null as nazev_obecmesto, null as  nazev_nuts, nazev_okres, nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,   ROZSAH,  platnost_od , platnost_do , platnost_autooprava, zdroj_autooprava, nazev_autooprava from (
-                          select * from (
-                                  select * from
-                                  (
-                                      select * from OKRES  where ID_OKRES = :id_okr
-                                  ) join op_kraj using(KRAJ_ID_KRAJ)
-                              ) join opatreni on opatreni_id_opatreni=opatreni.id_opatreni  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                              ) join kraj on KRAJ_ID_KRAJ=kraj.id_kraj
-
-                          union
-
-                          select distinct null as nazev_obecmesto, null as  nazev_nuts, null as nazev_okres, null as nazev_kraj, id_opatreni, nazev_opatreni, nazev_zkr, zdroj,  ROZSAH,  platnost_od , platnost_do, platnost_autooprava, zdroj_autooprava, nazev_autooprava from
-                         (
-                          select * from OP_STAT join OPATRENI using(id_opatreni)  where  (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null) and  trunc(sysdate)  >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                         )
-
-                          ) join polozka on id_opatreni=opatreni_id_opatreni
-                      ) join kategorie on kategorie.id_kategorie=kategorie_id_kategorie order by  PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc"""
-    misto_qu = """select distinct null as nazev_obecmesto, null as nazev_nuts, nazev_okres, nazev_kraj from (
-                               select * from (
-                                        select *
-                                        from okres
-                                        where ID_OKRES = :id_okr
-                                    )join kraj on kraj.id_kraj = KRAJ_ID_KRAJ
-                              );"""
-
-    with connection.cursor() as cursor:
-        cursor.execute(qu, {"id_okr": id_okres, "zobrazit_dopredu": DNI_DOPREDU})
-        array = return_as_array(cursor.fetchall(), cursor.description)
-
-        cursor.execute(misto_qu, {"id_okr": id_okres})
-        location = return_as_dict(cursor.fetchone(), cursor.description)
-        return display_by_cath(array), location
-
-
-def opatreni_om(id_obecmesto):
-    qu = """
-             select * from (
-         select * from (
-                               -- lokalni
-                               select nazev_obecmesto,
-                                      nazev_nuts,
-                                      nazev_okres,
-                                      nazev_kraj,
-                                      id_opatreni,
-                                      nazev_opatreni,
-                                      nazev_zkr,
-                                      zdroj,
-                                      ROZSAH,
-                                      platnost_od,
-                                      platnost_do, 
-                                      platnost_autooprava, 
-                                      zdroj_autooprava,
-                                      nazev_autooprava
-                               from (
-                                        select *
-                                        from (
-                                                 select *
-                                                 from (
-                                                          select *
-                                                          from (
-                                                                   select *
-                                                                   from (
-                                                                            select *
-                                                                            from (select * from obecmesto where id_obecmesto = :id_ob)
-                                                                        )
-                                                                            join nuts3 on nuts3_id_nuts = nuts3.id_nuts
-                                                               )
-                                                                   join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
-                                                      )
-                                                          join kraj on kraj.id_kraj = nuts3_kraj_id_kraj
-                                             )
-                                                 join op_om on id_obecmesto = op_om.obecmesto_id_obecmesto
-                                    )
-                                        join opatreni on opatreni_id_opatreni = opatreni.id_opatreni
-                               where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
-                                 and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-
-                               union
-                               -- nuts3
-                               select nazev_obecmesto,
-                                      nazev_nuts,
-                                      nazev_okres,
-                                      nazev_kraj,
-                                      id_opatreni,
-                                      nazev_opatreni,
-                                      nazev_zkr,
-                                      zdroj,
-                                      ROZSAH,
-                                      platnost_od,
-                                      platnost_do,
-                                      platnost_autooprava, 
-                                      zdroj_autooprava, 
-                                      nazev_autooprava
-                               from (
-                                        select *
-                                        from (
-                                                 select *
-                                                 from (
-                                                          select *
-                                                          from (
-                                                                   select *
-                                                                   from (select * from obecmesto where id_obecmesto = :id_ob)
-                                                                            join nuts3 on nuts3_id_nuts = nuts3.id_nuts
-                                                               )
-                                                      )
-                                                          join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
-                                             )
-                                                 join kraj on kraj.id_kraj = nuts3_kraj_id_kraj
-                                                 join op_nuts on op_nuts.nuts3_id_nuts = id_nuts)
-                                        join opatreni on opatreni_id_opatreni = opatreni.id_opatreni
-                               where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
-                                 and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-
-                               union
-                               -- okres
-                               select nazev_obecmesto,
-                                      nazev_nuts,
-                                      nazev_okres,
-                                      nazev_kraj,
-                                      id_opatreni,
-                                      nazev_opatreni,
-                                      nazev_zkr,
-                                      zdroj,
-                                      ROZSAH,
-                                      platnost_od,
-                                      platnost_do,
-                                      platnost_autooprava, 
-                                      zdroj_autooprava, 
-                                      nazev_autooprava
-                               from (
-                                        select *
-                                        from (
-                                                 select *
-                                                 from (
-                                                          select *
-                                                          from (
-                                                                   select *
-                                                                   from (select * from obecmesto where id_obecmesto = :id_ob)
-                                                                            join nuts3 on nuts3_id_nuts = nuts3.id_nuts)
-                                                      )
-                                                          join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
-                                             )
-                                                 join kraj on kraj.id_kraj = nuts3_kraj_id_kraj
-                                                 join op_okres on op_okres.okres_id_okres = id_okres
-                                    )
-                                        join opatreni on opatreni_id_opatreni = opatreni.id_opatreni
-                               where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
-                                 and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-
-                               union
-                               -- kraj
-
-                               select nazev_obecmesto,
-                                      nazev_nuts,
-                                      nazev_okres,
-                                      nazev_kraj,
-                                      id_opatreni,
-                                      nazev_opatreni,
-                                      nazev_zkr,
-                                      zdroj,
-                                      ROZSAH,
-                                      platnost_od,
-                                      platnost_do,
-                                      platnost_autooprava, 
-                                      zdroj_autooprava, 
-                                      nazev_autooprava
-                               from (
-                                        select *
-                                        from (
-                                                 select *
-                                                 from (
-                                                          select *
-                                                          from (
-                                                                   select *
-                                                                   from (select * from obecmesto where id_obecmesto = :id_ob)
-                                                                            join nuts3 on nuts3_id_nuts = nuts3.id_nuts
-                                                               )
-                                                                   join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
-                                                      )
-                                                          join op_kraj on op_kraj.kraj_id_kraj = nuts3_kraj_id_kraj
-                                             )
-                                                 join opatreni on opatreni_id_opatreni = opatreni.id_opatreni
-                                        where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
-                                          and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                                    )
-                                        join kraj on nuts3_kraj_id_kraj = kraj.id_kraj
-
-                                    -- stat
-                               union
-
-                               select null as nazev_obecmesto,
-                                      null as nazev_nuts,
-                                      null as nazev_okres,
-                                      null as nazev_kraj,
-                                      id_opatreni,
-                                      nazev_opatreni,
-                                      nazev_zkr,
-                                      zdroj,
-                                      ROZSAH,
-                                      platnost_od,
-                                      platnost_do,
-                                      platnost_autooprava, 
-                                      zdroj_autooprava, 
-                                      nazev_autooprava
-                               from (
-                                        select *
-                                        from OP_STAT
-                                                 join OPATRENI using (id_opatreni)
-                                        where (trunc(sysdate) < PLATNOST_DO or PLATNOST_DO is null)
-                                          and trunc(sysdate) >= PLATNOST_OD - :zobrazit_dopredu and je_platne=1
-                                    )
-                           )
-               )join polozka on id_opatreni=opatreni_id_opatreni
-              join kategorie on kategorie.id_kategorie=kategorie_id_kategorie order by PRIORITA_ZOBRAZENI asc, id_kategorie asc, TYP desc, PLATNOST_OD asc 
-              """
-    misto_qu = """select nazev_obecmesto, nazev_nuts, nazev_okres, nazev_kraj from (
-               select * from (
-                        select * from (
-                            select * from obecmesto where id_obecmesto=:id_ob
-                            ) join nuts3 on nuts3_id_nuts = nuts3.id_nuts
-                   )join OKRES on OKRES.NUTS3_ID_NUTS = ID_NUTS
-                 ) join kraj on kraj.id_kraj=nuts3_kraj_id_kraj;"""
-    with connection.cursor() as cursor:
-        cursor.execute(qu, {"id_ob": id_obecmesto, "zobrazit_dopredu": DNI_DOPREDU})
-        array = return_as_array(cursor.fetchall(), cursor.description)
-
-        cursor.execute(misto_qu, {"id_ob": id_obecmesto})
-        location = return_as_dict(cursor.fetchone(), cursor.description)
-
-        return display_by_cath(array), location
-
-
-# TODO Dokoncit seznam narizeni a polozek
-def seznam_opatreni(request):
-    with connection.cursor() as cursor:
-
-        cursor.execute(
-            """select * from (select * from opatreni ) join polozka on ID_OPATRENI=OPATRENI_ID_OPATRENI join KATEGORIE K on K.ID_KATEGORIE = POLOZKA.KATEGORIE_ID_KATEGORIE order by je_platne desc, PLATNOST_OD desc)"""
-        )
-
-        query_results = cursor.fetchall()
-
-        desc = (
-            cursor.description
-        )  # pouzivam dale, kde se z techle dat dela neco jako slovnik, co uz django schrousta
-
-        ### MAGIC ###
-        columns = []
-        for col in desc:
-            columns.append(col[0])
-
-        a = []
-
-        for line in query_results:
-            temp = {}
-            for i in range(0, len(line)):
-                temp[columns[i]] = line[i]
-            a.append(temp)
-
-        location = {}
-        i = 0
-        # setrizene podle kategorie
-        by_cath = []
-
-        existing = []
-        for col in a:
-            if (
-                "NAZEV_KAT" in col
-            ):  # fajn, ted zkontroluju, jestli uz jsem to vypsal, nebo ne
-                if col["NAZEV_KAT"] in existing:
-                    by_cath[len(by_cath) - 1]["narizeni"].append(col)
-                else:
-                    existing.append(col["NAZEV_KAT"])
-                    tmp = {"kategorie": col["NAZEV_KAT"], "narizeni": [col]}
-                    by_cath.append(tmp)
-
-        return render(
-            request,
-            "sites/opatreni.html",
-            {
-                "query_results": by_cath,
-                "location": location,
-                "posledni_databaze": posledni_databaze(),
-                "now": datetime.now(),
-                "kontrola": posledni_kontrola(),
-                "zastarala_data": zastarala_data(),
-            },
-        )
-
-
+# /aktualnost/
 def aktualnost(request):
     dict = {}
     dict2 = {}
@@ -646,21 +238,7 @@ def aktualnost(request):
     )
 
 
-def display_by_cath(array):
-    by_cath = []
-    existing = []
-    for col in array:
-        if "NAZEV_KAT" in col:
-            # fajn, ted zkontroluju, jestli uz jsem to vypsal, nebo ne
-            if col["NAZEV_KAT"] in existing:
-                by_cath[len(by_cath) - 1]["narizeni"].append(col)
-            else:
-                existing.append(col["NAZEV_KAT"])
-                tmp = {"kategorie": col["NAZEV_KAT"], "narizeni": [col]}
-                by_cath.append(tmp)
-    return by_cath
-
-
+# /opatreni/
 def opatreni(request):
     # ?obecmesto_id=replace"
     # "?nuts3_id=replace"'.
@@ -670,9 +248,9 @@ def opatreni(request):
     nuts3_id = args.get("nuts3_id", "")
     okres_id = args.get("okres_id", "")
     kraj_id = args.get("kraj_id", "")
-    flag = "nic"
+    # flag = "nic"
 
-    array = None
+    # array = None
     location = None
     res = None
 
@@ -755,6 +333,7 @@ def robots_txt(request):
     return HttpResponse("\n".join(headers), content_type="text/plain")
 
 
+# /o-projektu/
 def about(request):
     return render(
         request,
@@ -763,6 +342,7 @@ def about(request):
     )
 
 
+# /
 def home(request):
     try:
         r = requests.get(
@@ -821,11 +401,11 @@ def home(request):
     )
 
 
-# /statistiky
-def stats(request):
-    return render(request, "sites/statistiky.html")
+# /statistiky - INACTIVE
+# def stats(request):
+#     return render(request, "sites/statistiky.html")
 
-
+# admin/kontrola-zadaneho/
 def kontrola_zadaneho(request):
     args = request.GET.copy()
     try:

--- a/projektrouska/views.py
+++ b/projektrouska/views.py
@@ -1,11 +1,12 @@
-import json
+# import json
 import requests
 
 from datetime import datetime, timedelta
 
 from django.http import HttpResponse
-from django.views.decorators.http import require_GET
-from django.http import JsonResponse
+
+# from django.views.decorators.http import require_GET
+# from django.http import JsonResponse
 from django.shortcuts import render
 from django.db import connection
 
@@ -13,73 +14,19 @@ from projektrouska.aktualnost import kontrola
 from projektrouska.settings import DEV
 
 # from projektrouska.functions import *
-from projektrouska.functions import return_as_dict, return_as_array, calcmd5, format_num
+from projektrouska.functions import (
+    return_as_dict,
+    return_as_array,
+    calcmd5,
+    format_num,
+    strfdelta,
+)
 from projektrouska.api import *
 
-dni_dopredu = (
-    7  # urcuje v horizontu kolika dni se maji zobrazovat nadchazející opatreni
-)
+from projektrouska.sqls import posledni_kontrola, posledni_databaze
 
-
-# def indikator_aktualnost():
-#     with connection.cursor() as cursor:
-#         # query_results = cursor.fetchall()
-#         # desc = cursor.description
-
-#         cursor.execute(
-#             """
-#             select
-#                 *
-#             from
-#                 (select * from info order by DATE_UPDATED desc)
-#             where
-#                 ROWNUM <= 1
-#             """
-#         )
-
-#         dict = return_as_dict(cursor.fetchone(), cursor.description)
-
-#         if DEV is True:
-#             print(dict)
-
-#         if DEV is True and (datetime.now() - dict["DATE_UPDATED"]) < timedelta(
-#             minutes=10
-#         ):
-#             print("Aktualnost aktualizovana pred mene nez 10 minutami")
-
-
-def posledni_kontrola():
-    with connection.cursor() as cursor:
-        # query_results = cursor.fetchall()
-        # desc = cursor.description
-
-        cursor.execute(
-            """select * from (select * from INFO order by DATE_UPDATED desc ) where rownum <= 1;"""
-        )
-        dict = return_as_dict(cursor.fetchone(), cursor.description)
-        print(dict)
-        return dict
-
-
-def posledni_databaze():
-    with connection.cursor() as cursor:
-        last_qu = """select max(posledni_uprava) from(
-                       SELECT SCN_TO_TIMESTAMP(MAX(ora_rowscn)) as posledni_uprava from polozka
-                       union
-                       SELECT SCN_TO_TIMESTAMP(MAX(ora_rowscn)) as posledni_uprava from opatreni)"""
-        cursor.execute(last_qu)
-        last_update = cursor.fetchone()
-        return last_update[0]
 # urcuje v horizontu kolika dni se maji zobrazovat nadchazející opatreni
 DNI_DOPREDU = 7
-
-
-# source: https://stackoverflow.com/questions/8906926/formatting-timedelta-objects
-def strfdelta(tdelta, fmt):
-    d = {"days": tdelta.days}
-    d["hours"], rem = divmod(tdelta.seconds, 3600)
-    d["minutes"], d["seconds"] = divmod(rem, 60)
-    return fmt.format(**d)
 
 
 def zastarala_data():
@@ -767,7 +714,8 @@ def opatreni(request):
     )
 
 
-def opaterni_celoplosne(request):
+# /celostatni-opatreni
+def opatreni_celoplosne(request):
     array = opatreni_stat()[0]
 
     # oder by cathegory
@@ -797,13 +745,14 @@ def opaterni_celoplosne(request):
 
 
 # @require_GET
+# /robots.txt
 def robots_txt(request):
-    lines = [
+    headers = [
         "User-Agent: *",
         "Disallow: /private/",
         "Disallow: /junk/",
     ]
-    return HttpResponse("\n".join(lines), content_type="text/plain")
+    return HttpResponse("\n".join(headers), content_type="text/plain")
 
 
 def about(request):
@@ -872,6 +821,7 @@ def home(request):
     )
 
 
+# /statistiky
 def stats(request):
     return render(request, "sites/statistiky.html")
 


### PR DESCRIPTION
Cílem je přesunout maximum databázové logiky mimo views, aby se tím zpřehlednily.

Logika se přesouvá buď do `functions.py`, pokud jde o pomocné funkce, nebo to `sqls.py`, pokud jde o databázové dotazy.
Časem předpokládám, že se databázová logika z `sqls.py` přesune úplně do logiky modelů, což bude po tomto přeuspořádání výrazně jednodušší. 